### PR TITLE
Added AndroidManifest to the lib

### DIFF
--- a/elasticdownload/src/main/AndroidManifest.xml
+++ b/elasticdownload/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+package="is.arontibo.library">
+</manifest>


### PR DESCRIPTION
While trying to build the project, it seems `AndroidManifest` file is missing from library project.
