### PR TITLE
Added the ability to set the background color

### DIFF
--- a/elasticdownload/src/main/java/is/arontibo/library/ElasticDownloadView.java
+++ b/elasticdownload/src/main/java/is/arontibo/library/ElasticDownloadView.java
@@ -107,5 +107,33 @@ public class ElasticDownloadView extends FrameLayout implements IntroView.EnterA
 
         // Do further actions if necessary
     }
+    
+    
+    /////////////////////////////////////////////////////////////////////////////
+    ///Added on 2016-07-29 by PGMacDesign as per Issue #27 in Github/////////////
+    /////////////////////////////////////////////////////////////////////////////
+    /**
+     * Set the background color of the Elastic Download View
+     * @param passedColor int Color Color to set the background
+     */
+    public void setBackgroundColor(int passedColor){
+        this.mBackgroundColor = passedColor;
+        this.mProgressDownloadView.setBackgroundColor(mBackgroundColor);
+    }
+
+    /**
+     * Overloaded method, takes in a String color to parse
+     * @param passedColor String of a color hex color (IE: #fd5c79) that can be parsed by
+     *                    Color.parseColor(string)
+     */
+    public void setBackgroundColor(String passedColor){
+        if(passedColor == null){
+            return;
+        }
+        try {
+            int color = Color.parseColor(passedColor);
+            this.setBackgroundColor(color);
+        } catch (Exception e){}
+    }
 
 }


### PR DESCRIPTION
Added 2 methods for setting the background color of the Elastic view. It should take in either an int color or a String and parse the color. If the string is null or the parsing fails, nothing will be set and it will retain the original color

I created a pull request into the bugfix branch (not master) so you can update after testing if you would like. I tested it myself before pushing and it seems to have no issues that I can find.
