### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage
 Grab it from maven:
 
 ```groovy
-    compile 'com.github.tibolte:elasticdownload:1.0.+'
+    implementation 'com.github.tibolte:elasticdownload:1.0.+'
 ````
 
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.